### PR TITLE
Scope error when returning a public ip for VM

### DIFF
--- a/lib/kontena/machine/azure/master_provisioner.rb
+++ b/lib/kontena/machine/azure/master_provisioner.rb
@@ -33,6 +33,7 @@ module Kontena
           cloud_service_name = generate_cloud_service_name
           vm_name = cloud_service_name
           master_url = ''
+          public_ip = nil
           spinner "Creating an Azure Virtual Machine #{vm_name.colorize(:cyan)}" do
             if opts[:virtual_network].nil?
               location = opts[:location].downcase.gsub(' ', '-')
@@ -69,6 +70,7 @@ module Kontena
 
 
             virtual_machine =  client.vm_management.create_virtual_machine(params,options)
+            public_ip = virtual_machine.ipaddress
 
             if opts[:ssl_cert]
               master_url = "https://#{virtual_machine.ipaddress}"
@@ -93,7 +95,7 @@ module Kontena
 
           {
             name: opts[:name] || cloud_service_name.sub('kontena-master-', ''),
-            public_ip: virtual_machine.ipaddress,
+            public_ip: public_ip,
             provider: 'azure',
             version: master_version,
             code: opts[:initial_admin_code]


### PR DESCRIPTION
Azure Master Provisioning - undefined local variable or method `virtual_machine'

Fixes https://github.com/kontena/kontena/issues/1456

```
/Library/Ruby/Gems/2.0.0/gems/kontena-plugin-azure-0.2.1/lib/kontena/machine/azure/master_provisioner.rb:96:in `run!': undefined local variable or method `virtual_machine' for #<Kontena::Machine::Azure::MasterProvisioner:0x007f96745e29c0> (NameError)
	from /Library/Ruby/Gems/2.0.0/gems/kontena-plugin-azure-0.2.1/lib/kontena/plugin/azure/master/create_command.rb:23:in `execute'
	from /Library/Ruby/Gems/2.0.0/gems/kontena-cli-1.0.0/lib/kontena/command.rb:187:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-1.1.1/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /Library/Ruby/Gems/2.0.0/gems/kontena-cli-1.0.0/lib/kontena/command.rb:187:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-1.1.1/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /Library/Ruby/Gems/2.0.0/gems/kontena-cli-1.0.0/lib/kontena/command.rb:187:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-1.1.1/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /Library/Ruby/Gems/2.0.0/gems/kontena-cli-1.0.0/lib/kontena/command.rb:187:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-1.1.1/lib/clamp/command.rb:132:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/kontena-cli-1.0.0/bin/kontena:16:in `<top (required)>'
	from /usr/bin/kontena:23:in `load'
	from /usr/bin/kontena:23:in `<main>'
```
